### PR TITLE
Building a valid ePub of TRPL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  VERSION: "4.2.6"
+  EPUBCHECK: "https://github.com/w3c/epubcheck/releases/download"
 
 jobs:
   build:
@@ -28,3 +30,14 @@ jobs:
         run: cargo test --verbose
       - name: Check cargo clippy warnings
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      # Test TRPL ePub
+      - name: Install nocomment preprocessor
+        run: cargo install mdbook-nocomment
+      - name: Run example program build_trpl
+        run: cargo run --example build_trpl -- --dest target/book target/book
+      - name: Install EPUBCheck
+        run: |
+          curl -L -o echeck.zip $EPUBCHECK/v$VERSION/epubcheck-$VERSION.zip
+          unzip echeck.zip
+      - name: Validate TRPL Epub
+        run: java -jar $GITHUB_WORKSPACE/epubcheck-$VERSION/epubcheck.jar -f "$GITHUB_WORKSPACE/target/book/The Rust Programming Language.epub"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,7 @@ dependencies = [
 name = "mdbook-epub"
 version = "0.4.15"
 dependencies = [
+ "anyhow",
  "env_logger 0.7.1",
  "epub",
  "epub-builder",
@@ -701,6 +702,7 @@ dependencies = [
  "toml",
  "ureq",
  "url",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "mdbook-epub"
 doc = false
 
 [dependencies]
-epub-builder = "0.5"
+epub-builder = {git = "https://github.com/dieterplex/epub-builder", tag = "v0.6.0"}
 anyhow = "1"
 thiserror = "1.0"
 pulldown-cmark = "0.9"
@@ -43,7 +43,7 @@ url = "2.2"
 ureq = "2.5"
 
 [dependencies.zip]
-version = "0.5"
+version = "0.6"
 default-features = false
 features = ["deflate"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ doc = false
 
 [dependencies]
 epub-builder = "0.5"
+anyhow = "1"
 thiserror = "1.0"
 pulldown-cmark = "0.9"
 semver = "0.11"
@@ -40,6 +41,11 @@ toml = "0.5"
 html_parser = "0.6.2"
 url = "2.2"
 ureq = "2.5"
+
+[dependencies.zip]
+version = "0.5"
+default-features = false
+features = ["deflate"]
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/examples/build_trpl.rs
+++ b/examples/build_trpl.rs
@@ -1,0 +1,102 @@
+//! This example builds an ePub version of TRPL that needs built-in link preprocessor to include
+//! sources and to remove invalid HTML comments that causing fatal error found by epubcheck.
+//! The book source will download from official github repo and extract to `book/` by default.
+//! And then it would build with preprocessor `nocomment` to generate the epub file.
+//! Note that it requires you to have crate `mdbook-nocomment` installed.
+//!
+//! Run this example with:
+//!
+//! ```
+//! cargo run --example build_trpl -- --dest . book/
+//! ```
+
+use std::io::{self, Cursor, Read, Seek, Write};
+use std::path::{Path, PathBuf};
+use structopt::StructOpt;
+
+// Inject config value to activate the preprocessor `nocomment` with this env var.
+// See https://rust-lang.github.io/mdBook/format/configuration/environment-variables.html
+const BOOK_PREPROCESSOR: &str = "MDBOOK_PREPROCESSOR__NOCOMMENT";
+const BOOK_ARCHIVE_URL: &str = "https://github.com/rust-lang/book/archive/refs/heads/main.zip";
+const BOOK_BUF_SIZE: usize = 4 * 1024 * 1024;
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::from_args();
+    let dest = args.dest.as_path();
+    let book_root = args.root.as_path();
+
+    // Download & extract
+    let resp = ureq::get(BOOK_ARCHIVE_URL).call()?;
+    let mut buf: Vec<u8> = Vec::with_capacity(BOOK_BUF_SIZE);
+    resp.into_reader().read_to_end(&mut buf)?;
+    let mut archive = zip::ZipArchive::new(Cursor::new(buf))?;
+    extract(&mut archive, &book_root)?;
+
+    std::env::set_var(BOOK_PREPROCESSOR, "");
+    let md = mdbook::MDBook::load(book_root)
+        .map_err(|e| anyhow::anyhow!("Could not load mdbook: {}", e))?;
+    let outfile = mdbook_epub::output_filename(dest, &md.config);
+
+    match mdbook_epub::generate_with_preprocessor(&md, dest) {
+        Ok(_) => writeln!(
+            &mut io::stderr(),
+            "Successfully wrote epub document to {:?}!",
+            outfile,
+        )
+        .unwrap(),
+        Err(err) => writeln!(&mut io::stderr(), "Error: {}", err).unwrap(),
+    };
+    Ok(())
+}
+
+/// Modified `ZipArchive::extract()`. Path::strip_prefix is added to remove top level directory.
+fn extract<R: Read + Seek, P: AsRef<Path>>(
+    archive: &mut zip::ZipArchive<R>,
+    directory: P,
+) -> anyhow::Result<()> {
+    use std::fs;
+    const ZIP_PREFIX: &str = "book-main";
+
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i)?;
+        let filepath = file
+            .enclosed_name()
+            .ok_or(zip::result::ZipError::InvalidArchive("Invalid file path"))?
+            .strip_prefix(ZIP_PREFIX)?;
+
+        let outpath = directory.as_ref().join(filepath);
+
+        if file.name().ends_with('/') {
+            fs::create_dir_all(&outpath)?;
+        } else {
+            if let Some(p) = outpath.parent() {
+                if !p.exists() {
+                    fs::create_dir_all(&p)?;
+                }
+            }
+            let mut outfile = fs::File::create(&outpath)?;
+            io::copy(&mut file, &mut outfile)?;
+        }
+        // Get and Set permissions
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Some(mode) = file.unix_mode() {
+                fs::set_permissions(&outpath, fs::Permissions::from_mode(mode))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, StructOpt)]
+struct Args {
+    #[structopt(
+        help = "The book to render.",
+        parse(from_os_str),
+        default_value = "book/"
+    )]
+    root: PathBuf,
+    #[structopt(short, long, default_value = "target/book/")]
+    dest: PathBuf,
+}

--- a/src/bin/mdbook-epub.rs
+++ b/src/bin/mdbook-epub.rs
@@ -31,7 +31,7 @@ fn main() {
 fn run(args: &Args) -> Result<(), Error> {
     // get a `RenderContext`, either from stdin (because we're used as a plugin)
     // or by instrumenting MDBook directly (in standalone mode).
-    let ctx: RenderContext = if args.standalone {
+    if args.standalone {
         let error = format!(
             "book.toml root file is not found by a path {:?}",
             &args.root.display()
@@ -43,14 +43,17 @@ fn run(args: &Args) -> Result<(), Error> {
             destination.display()
         );
         debug!("EPUB book config is : {:?}", md.config);
-        RenderContext::new(md.root, md.book, md.config, destination)
+        if args.preprocess {
+            mdbook_epub::generate_with_preprocessor(&md, &destination)
+        } else {
+            let ctx = RenderContext::new(md.root, md.book, md.config, destination);
+            mdbook_epub::generate(&ctx)
+        }
     } else {
-        serde_json::from_reader(io::stdin()).map_err(|_| Error::RenderContext)?
-    };
-
-    mdbook_epub::generate(&ctx)?;
-
-    Ok(())
+        let ctx: RenderContext =
+            serde_json::from_reader(io::stdin()).map_err(|_| Error::RenderContext)?;
+        mdbook_epub::generate(&ctx)
+    }
 }
 
 #[derive(Debug, Clone, StructOpt)]
@@ -61,6 +64,12 @@ struct Args {
         help = "Run standalone (i.e. not as a mdbook plugin)"
     )]
     standalone: bool,
+    #[structopt(
+        short = "p",
+        long = "preprocess",
+        help = "Enable preprocessing for standalone mode."
+    )]
+    preprocess: bool,
     #[structopt(help = "The book to render.", parse(from_os_str), default_value = ".")]
     root: PathBuf,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate serde_json;
 
 use mdbook::config::Config as MdConfig;
 use mdbook::renderer::RenderContext;
+use mdbook::MDBook;
 use semver::{Version, VersionReq};
 use std::fs::{create_dir_all, File};
 use std::path::{Path, PathBuf};
@@ -131,5 +132,27 @@ pub fn output_filename(dest: &Path, config: &MdConfig) -> PathBuf {
     match config.book.title {
         Some(ref title) => dest.join(title).with_extension("epub"),
         None => dest.join("book.epub"),
+    }
+}
+
+/// Generate an `EPUB` version of the provided book with MDBook preprocessor applied.
+pub fn generate_with_preprocessor(md: &MDBook, dest: &Path) -> Result<(), Error> {
+    let renderer = EpubRenderer(dest.to_path_buf());
+    md.execute_build_process(&renderer)
+        .map_err(|err| err.into())
+}
+
+struct EpubRenderer(PathBuf);
+
+impl mdbook::Renderer for EpubRenderer {
+    fn name(&self) -> &str {
+        "epub"
+    }
+
+    fn render(&self, ctx: &RenderContext) -> mdbook::errors::Result<()> {
+        trace!("ctx={:?}, new dest={:?}", &ctx, &self.0);
+        let mut ctx = ctx.to_owned();
+        ctx.destination = self.0.to_owned();
+        generate(&ctx).map_err(|e| anyhow::anyhow!("Error generating book: {:?}", e))
     }
 }


### PR DESCRIPTION
- Add a new API to generate with preprocessors applied
  - Make mdbook's *include helper work (by LinkPreprocessor)
- Add an example ptogram to build TRPL
- Update CI workflow
  - Build TRPL with built-in preprocessor
  - Fix epub error: double hyphen with external preprocessor: nocomment
  - Validate with epubcheck
- Use forked epub-builder to fix epub error: unescaped chapter title